### PR TITLE
Fix typo in git_repo

### DIFF
--- a/lib/kochiku/git_repo.rb
+++ b/lib/kochiku/git_repo.rb
@@ -17,7 +17,7 @@ module Kochiku
             # update the cached repo
             remote_list = `git remote -v | grep #{remote_name}`
             unless remote_list.include?(remote_name)
-              run! "git remote add #{remote_name} #{remote_url}"
+              run! "git remote add #{remote_name} #{repo_url}"
             end
             synchronize_with_remote(remote_name, sha, branch)
             #TODO: doing this here is questionable - this may not work for forks


### PR DESCRIPTION
To: @cheister @nolman 

Apparently this has been broken since it was introduced in 855d5001a03735fe9f6634bca1185d180fb48c7a.
