### PR TITLE
Switch from SIGHUP to SIGTERM

### DIFF
--- a/lib/kochiku/build_strategies/build_all_strategy.rb
+++ b/lib/kochiku/build_strategies/build_all_strategy.rb
@@ -52,16 +52,16 @@ module BuildStrategy
       end
     end
 
-    def kill_process(pid, sig = "HUP")
+    def kill_process(pid, sig = "TERM")
       begin
         Timeout.timeout(10) do
           Process.kill(sig, pid)
           Process.wait(pid)
         end
       rescue Timeout::Error
-        # The process did not exit from SIGHUP within the timeout
+        # The process did not exit within the timeout
         # no more CPU time for the child process
-        kill_process(pid, 9) if sig == "HUP"
+        kill_process(pid, 9)
       rescue Errno::ESRCH, Errno::ECHILD # Process has already exited
       end
     end


### PR DESCRIPTION
to: @nolman 

SIGHUP seems to me to be the wrong signal to use in this situation. I tested it on a ruby process and it does work to exit it but it would be totally acceptable for a Ruby process to catch SIGHUP and reload a config or something.

AFAIK SIGTERM followed by SIGKILL is more suitable.

Nolan, do you remember your reasoning for picking SIGHUP?
