### PR TITLE
New error handling for network calls

### DIFF
--- a/lib/kochiku/jobs/build_attempt_job.rb
+++ b/lib/kochiku/jobs/build_attempt_job.rb
@@ -95,8 +95,8 @@ class BuildAttemptJob < JobBase
     yield
   rescue Errno::EHOSTUNREACH, RestClient::Exception
     tries = (tries || 0) + 1
-    if tries < 3
-      sleep 1
+    if tries <= 3
+      sleep(tries**tries)
       retry
     end
   end


### PR DESCRIPTION
This is to try and prevent the web server's idea of the worker's status from being inaccurate by making the worker more persistent.
