### PR TITLE
with_http_retries wasn't raising after the final failure

### DIFF
--- a/lib/kochiku/jobs/build_attempt_job.rb
+++ b/lib/kochiku/jobs/build_attempt_job.rb
@@ -98,6 +98,8 @@ class BuildAttemptJob < JobBase
     if tries <= 3
       sleep(tries**tries)
       retry
+    else
+      raise
     end
   end
 

--- a/spec/jobs/build_attempt_job_spec.rb
+++ b/spec/jobs/build_attempt_job_spec.rb
@@ -177,4 +177,18 @@ describe BuildAttemptJob do
       end
     end
   end
+
+  describe "#with_http_retries" do
+    before do
+      allow(subject).to receive(:sleep)
+    end
+
+    it "should raise after retrying" do
+      expect {
+        subject.send(:with_http_retries) do
+          raise Errno::EHOSTUNREACH
+        end
+      }.to raise_error(Errno::EHOSTUNREACH)
+    end
+  end
 end


### PR DESCRIPTION
This oversight is causing `no implicit conversion of nil into String` to overshadow the actual error message in our logs.
