### PR TITLE
Shared Cache Strategy fix: allow '.git' suffix to be optional

### DIFF
--- a/lib/kochiku/git_strategies/shared_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/shared_cache_strategy.rb
@@ -45,7 +45,7 @@ module GitStrategy
           # update submodules. attempt to use references. best-effort.
           submodules = Cocaine::CommandLine.new('git', 'config --get-regexp "^submodule\..*\.url$"', expected_outcodes: [0,1]).run
           submodules.each_line do |submodule|
-            _, path, url = submodule.match(/^submodule\.(.+?)\.url .+?([^\/]+\/[^\/]+\.git)$/).to_a
+            _, path, url = submodule.match(/^submodule\.(.+?)\.url .+?([^\/]+\/[^\/]+(\.git)?)$/).to_a
             shared_repo_dir = File.join(Kochiku::Worker.settings.git_shared_root, url || 'does-not-exist')
 
             if Dir.exists?(shared_repo_dir)

--- a/lib/kochiku/git_strategies/shared_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/shared_cache_strategy.rb
@@ -51,7 +51,7 @@ module GitStrategy
             if Dir.exists?(shared_repo_dir)
               Cocaine::CommandLine.new('git', 'config --replace-all submodule.:path.url :shared').run(shared: shared_repo_dir, path: path)
             end
-            Cocaine::CommandLine.new('git', 'submodule --quiet update :path').run(path: path)
+            Cocaine::CommandLine.new('git', 'submodule --quiet update -- :path').run(path: path)
           end
         end
       end


### PR DESCRIPTION
if the url is missing ".git" the regex match fails and the submodule update command gets run without a path.