### PR TITLE
Fix test env logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .bundle/
 tmp/
 log/
-vendor/ruby

--- a/lib/kochiku/worker.rb
+++ b/lib/kochiku/worker.rb
@@ -29,11 +29,19 @@ module Kochiku
       end
 
       def logger
-        @logger ||= Logger.new(STDOUT).tap do |logger|
-          logger.formatter = proc do |severity, datetime, progname, msg|
+        @logger ||= begin
+          default_logger = Logger.new(STDOUT)
+          default_logger.formatter = proc do |severity, datetime, progname, msg|
             "%5s [%s] %d: %s: %s\n" % [severity, datetime.strftime('%H:%M:%S %Y-%m-%d'), $$, progname, msg2str(msg)]
           end
+          Cocaine::CommandLine.logger = default_logger
+          default_logger
         end
+      end
+
+      def logger=(logger)
+        @logger = logger
+        Cocaine::CommandLine.logger = @logger
       end
 
       def msg2str(msg)
@@ -57,5 +65,3 @@ end
 
 Resque.redis = Redis.new(:host => Kochiku::Worker.settings.redis_host)
 Resque.redis.namespace = "resque:kochiku"
-
-Cocaine::CommandLine.logger = Kochiku::Worker.logger

--- a/lib/kochiku/worker.rb
+++ b/lib/kochiku/worker.rb
@@ -32,7 +32,7 @@ module Kochiku
         @logger ||= begin
           default_logger = Logger.new(STDOUT)
           default_logger.formatter = proc do |severity, datetime, progname, msg|
-            "%5s [%s] %d: %s: %s\n" % [severity, datetime.strftime('%H:%M:%S %Y-%m-%d'), $$, progname, msg2str(msg)]
+            "%5s [%s] %d: %s\n" % [severity, datetime.strftime('%H:%M:%S %Y-%m-%d'), $$, msg2str(msg)]
           end
           Cocaine::CommandLine.logger = default_logger
           default_logger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ require 'kochiku/worker'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| load f}
 
+Dir.mkdir("log")
+test_logger = Logger.new("log/test.log", 2)
+test_logger.level = Logger::DEBUG
+Kochiku::Worker.logger = test_logger
 
 RSpec.configure do |config|
   config.expose_dsl_globally = false
@@ -36,7 +40,5 @@ RSpec.configure do |config|
     allow(Cocaine::CommandLine).to receive(:new).with('git fetch', anything) { double('git fetch', :run => nil, :exit_status => 0) }
     allow(Cocaine::CommandLine).to receive(:new).with('git submodule update', anything) { double('git submodule update', :run => nil) }
     allow(Cocaine::CommandLine).to receive(:new).with('git rev-list', anything) { double('git rev-list', :run => nil) }
-
-    allow(Kochiku::Worker.logger).to receive(:info)
   end
 end


### PR DESCRIPTION
Currently when you run the rspec tests the logger information goes into a blackhole. Changed to send the log output to log/test.log.

R: @Shenil 