### PR TITLE
Fix submodule regex to not match newlines

### DIFF
--- a/lib/kochiku/git_strategies/shared_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/shared_cache_strategy.rb
@@ -45,13 +45,13 @@ module GitStrategy
           # update submodules. attempt to use references. best-effort.
           submodules = Cocaine::CommandLine.new('git', 'config --get-regexp "^submodule\..*\.url$"', expected_outcodes: [0,1]).run
           submodules.each_line do |submodule|
-            _, path, url = submodule.match(/^submodule\.(.+?)\.url .+?([^\/]+\/[^\/]+(\.git)?)$/).to_a
+            _, path, url = submodule.strip.match(/^submodule\.(.+?)\.url .+?([^\/]+\/[^\/\n]+)$/).to_a
             shared_repo_dir = File.join(Kochiku::Worker.settings.git_shared_root, url || 'does-not-exist')
 
             if Dir.exists?(shared_repo_dir)
               Cocaine::CommandLine.new('git', 'config --replace-all submodule.:path.url :shared').run(shared: shared_repo_dir, path: path)
             end
-            Cocaine::CommandLine.new('git', 'submodule --quiet update -- :path').run(path: path)
+            Cocaine::CommandLine.new('git', 'submodule update -- :path').run(path: path)
           end
         end
       end


### PR DESCRIPTION
What I implemented in #34 was not correct. The real problem is that the regex match was including the newline at the end which would cause the `Dir.exists?` check to fail. The `strip` and added `\n` in the inverse character group are redundant but safer in case the code changes.

R: @shenil