### PR TITLE
Retry if git ref is not immediately found

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "resque"
 gem "json"
 
 gem "rest-client", require: false
+gem "retryable", require: false
 gem "cocaine"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    retryable (2.0.1)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -104,5 +105,6 @@ DEPENDENCIES
   rake
   resque
   rest-client
+  retryable
   rspec (~> 3.0)
   webmock

--- a/lib/kochiku/git_strategies/local_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/local_cache_strategy.rb
@@ -26,7 +26,6 @@ module GitStrategy
         run! "git clone #{cached_repo_path} #{tmp_dir}"
 
         Dir.chdir(tmp_dir) do
-          raise Kochiku::Worker::GitRepo::RefNotFoundError.new("Build Ref #{sha} not found in #{repo_url}") unless system("git rev-list --quiet -n1 #{sha}")
           run! "git checkout --quiet #{sha}"
 
           run! "git submodule --quiet init"
@@ -66,6 +65,10 @@ module GitStrategy
           end
 
           synchronize_with_remote(remote_name)
+
+          if !sha.nil? && !system("git rev-list --quiet -n1 #{sha}")
+            raise Kochiku::Worker::GitRepo::RefNotFoundError.new("Build Ref #{sha} not found in #{repo_url}")
+          end
 
           Cocaine::CommandLine.new("git submodule update", "--init --quiet").run
         end

--- a/spec/jobs/build_attempt_job_spec.rb
+++ b/spec/jobs/build_attempt_job_spec.rb
@@ -157,8 +157,9 @@ RSpec.describe BuildAttemptJob do
     end
 
     it "should be able to retry, even if the IO object has been closed" do
+      Retryable.enable
+      allow(Kernel).to receive(:sleep)
       stub_request(:post, "#{master_host}/build_attempts/#{build_attempt_id}/build_artifacts").to_return(:status => 500, :body => "", :headers => {})
-      allow(subject).to receive(:sleep)
 
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
@@ -175,6 +176,8 @@ RSpec.describe BuildAttemptJob do
           expect(WebMock).to have_requested(:post, "#{master_host}/build_attempts/#{build_attempt_id}/build_artifacts").times(4)
         end
       end
+
+      Retryable.disable
     end
   end
 

--- a/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
+++ b/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 RSpec.describe GitStrategy::LocalCache do
   describe "#synchronize_with_remote" do
+    before { Retryable.enable }
+    after { Retryable.disable }
+
     it "should throw an exception after the third fetch attempt" do
       allow(Kochiku::Worker).to receive(:logger) { double('logger', :warn => nil) }
       fetch_double = double('git fetch')
       expect(fetch_double).to receive(:run).exactly(3).times.and_raise(Cocaine::ExitStatusError)
-      allow(Cocaine::CommandLine).to receive(:new).with('git fetch', anything) { fetch_double }
-      expect(GitStrategy::LocalCache).to receive(:sleep).exactly(2).times
+      expect(Cocaine::CommandLine).to receive(:new).with('git fetch', anything).and_return(fetch_double).exactly(3).times
 
       expect { GitStrategy::LocalCache.send(:synchronize_with_remote, "master") }.to raise_error(Cocaine::ExitStatusError)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,11 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching! # same as what's above
 
+  config.before :suite do
+    # Disable Retryable; enable for individual tests if desired.
+    Retryable.disable
+  end
+
   config.before :each do
     WebMock.disable_net_connect!
 


### PR DESCRIPTION
Recreates the logic that exists in Kochiku for the PartitioningJob. This is necessary if the partitioner is reading from a different git mirror than the kochiku-workers.

This change has the unfortunate side effect that if the git commit were actually deleted then the BuildAttemptJob will spin uselessly for 1 minute waiting for it to appear.

R: @Shenil 