### PR TITLE
Fix execute_build method parameter bug

### DIFF
--- a/lib/kochiku/build_strategies/log_and_random_fail_strategy.rb
+++ b/lib/kochiku/build_strategies/log_and_random_fail_strategy.rb
@@ -1,6 +1,6 @@
 module BuildStrategy
   class LogAndRandomFailStrategy
-    def execute_build(build_kind, test_files, test_command, timeout, options)
+    def execute_build(build_attempt_id, build_kind, test_files, test_command, timeout, options)
       system %[ruby -e "now = Time.now.usec; File.open('now.log', 'w') {|f|f.write(now)}; exit(now % 3 == 0 ? 1 : 0)"]
     end
 

--- a/lib/kochiku/build_strategies/no_op_strategy.rb
+++ b/lib/kochiku/build_strategies/no_op_strategy.rb
@@ -1,6 +1,6 @@
 module BuildStrategy
   class NoOpStrategy
-    def execute_build(build_kind, test_files, test_command, timeout, options)
+    def execute_build(build_attempt_id, build_kind, test_files, test_command, timeout, options)
       true
     end
 


### PR DESCRIPTION
The method in lib/kochiku/build_strategies/log_and_random_fail_strategy.rb should accept build_id as first argument