### PR TITLE
Improve performance of SharedCache git strategy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retryable (2.0.3)
+    retryable (2.0.4)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.2
+   1.16.0

--- a/lib/kochiku/git_repo.rb
+++ b/lib/kochiku/git_repo.rb
@@ -9,19 +9,21 @@ module Kochiku
 
       class << self
         def inside_copy(cached_repo_name, remote_name, repo_url, sha)
-          Dir.mktmpdir(nil, WORKING_DIR) do |dir|
-            case Kochiku::Worker.settings.git_strategy
-              when 'localcache'
-                GitStrategy::LocalCache.clone_and_checkout(dir, cached_repo_name, remote_name, repo_url, sha)
-              when 'sharedcache'
-                GitStrategy::SharedCache.clone_and_checkout(dir, repo_url, sha)
-              else
-                raise 'unknown git strategy'
-            end
+          dir = case Kochiku::Worker.settings.git_strategy
+                when 'localcache'
+                  GitStrategy::LocalCache.clone_and_checkout(cached_repo_name, remote_name, repo_url, sha)
+                when 'sharedcache'
+                  GitStrategy::SharedCache.clone_and_checkout(repo_url, sha)
+                else
+                  raise 'unknown git strategy'
+                end
 
-            Dir.chdir(dir) do
-              yield
-            end
+          Dir.chdir(dir) do
+            yield
+          end
+
+          if Kochiku::Worker.settings.git_strategy == 'localcache'
+            FileUtils.remove_entry(dir)
           end
         end
       end

--- a/lib/kochiku/git_repo.rb
+++ b/lib/kochiku/git_repo.rb
@@ -8,10 +8,10 @@ module Kochiku
       WORKING_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'tmp', 'build-partition'))
 
       class << self
-        def inside_copy(cached_repo_name, remote_name, repo_url, sha)
+        def inside_copy(repo_url, sha)
           dir = case Kochiku::Worker.settings.git_strategy
                 when 'localcache'
-                  GitStrategy::LocalCache.clone_and_checkout(cached_repo_name, remote_name, repo_url, sha)
+                  GitStrategy::LocalCache.clone_and_checkout(repo_url, sha)
                 when 'sharedcache'
                   GitStrategy::SharedCache.clone_and_checkout(repo_url, sha)
                 else

--- a/lib/kochiku/git_strategies/local_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/local_cache_strategy.rb
@@ -17,18 +17,18 @@ module GitStrategy
   # enough workers to overwhelm your primary git server or git mirror.
   class LocalCache
     class << self
-      # TODO: make this conform to the same api as nfs strategy. don't need cache name, remote name, etc
-      def clone_and_checkout(cached_repo_name, remote_name, repo_url, sha)
+      def clone_and_checkout(repo_url, commit)
         tmp_dir = Dir.mktmpdir(nil, Kochiku::Worker::GitRepo::WORKING_DIR)
 
-        cached_repo_path = File.join(Kochiku::Worker::GitRepo::WORKING_DIR, cached_repo_name)
-        synchronize_cache_repo(cached_repo_path, remote_name, repo_url, sha)
+        repo_path = repo_url.match(/.+?([^:\/]+\/[^\/]+)\.git\z/)[1]
+        cached_repo_path = File.join(Kochiku::Worker::GitRepo::WORKING_DIR, repo_path)
+        synchronize_cache_repo(cached_repo_path, repo_url, commit)
 
         # clone local repo (fast!)
         run! "git clone #{cached_repo_path} #{tmp_dir}"
 
         Dir.chdir(tmp_dir) do
-          run! "git checkout --quiet #{sha}"
+          run! "git checkout --quiet #{commit}"
 
           run! "git submodule --quiet init"
 
@@ -57,21 +57,16 @@ module GitStrategy
 
       private
 
-      def synchronize_cache_repo(cached_repo_path, remote_name, repo_url, sha)
-        if !File.directory?(cached_repo_path)
-          clone_repo(repo_url, remote_name, cached_repo_path)
+      def synchronize_cache_repo(cached_repo_path, repo_url, commit)
+        if !Dir.exist?(cached_repo_path)
+          clone_repo(repo_url, cached_repo_path)
         end
         Dir.chdir(cached_repo_path) do
-          remote_url = Cocaine::CommandLine.new("git config --get remote.#{remote_name}.url").run.chomp
-          if remote_url != repo_url
-            puts "#{remote_url.inspect} does not match #{repo_url.inspect}. Updating it."
-            Cocaine::CommandLine.new("git remote set-url #{remote_name} #{repo_url}").run
-          end
+          harmonize_remote_url(repo_url)
+          synchronize_cache_repo
 
-          synchronize_with_remote(remote_name)
-
-          if !sha.nil? && !system("git rev-list --quiet -n1 #{sha}")
-            raise Kochiku::Worker::GitRepo::RefNotFoundError.new("Build Ref #{sha} not found in #{repo_url}")
+          if !commit.nil? && !system("git rev-list --quiet -n1 #{commit}")
+            raise Kochiku::Worker::GitRepo::RefNotFoundError.new("Build Ref #{commit} not found in #{repo_url}")
           end
 
           Cocaine::CommandLine.new("git submodule update", "--init --quiet").run
@@ -84,18 +79,28 @@ module GitStrategy
         end
       end
 
-      def clone_repo(repo_url, remote_name, cached_repo_path)
-        Cocaine::CommandLine.new("git clone", "--recursive --origin #{remote_name} #{repo_url} #{cached_repo_path}").run
+      def clone_repo(repo_url, cached_repo_path)
+        Cocaine::CommandLine.new("git clone", "--recursive #{repo_url} #{cached_repo_path}").run
       end
 
-      def synchronize_with_remote(remote_name)
+      # fancy name for run 'git fetch' on the cache repo
+      def synchronize_cache_repo
         exception_cb = Proc.new do |exception|
           Kochiku::Worker.logger.warn(exception)
         end
 
         # likely caused by another 'git fetch' that is currently in progress. Wait a few seconds and try again
         Retryable.retryable(tries: 3, on: Cocaine::ExitStatusError, sleep: lambda { |n| 15*n }, exception_cb: exception_cb) do
-          Cocaine::CommandLine.new("git fetch", "--quiet --prune --no-tags #{remote_name}").run
+          Cocaine::CommandLine.new("git fetch", "--quiet --prune --no-tags").run
+        end
+      end
+
+      # Update the remote url for the git repository if it has changed
+      def harmonize_remote_url(expected_url)
+        remote_url = Cocaine::CommandLine.new("git config --get remote.origin.url").run.chomp
+        if remote_url != expected_url
+          puts "#{remote_url.inspect} does not match #{expected_url.inspect}. Updating it."
+          Cocaine::CommandLine.new("git remote", "set-url origin #{expected_url}").run
         end
       end
     end

--- a/lib/kochiku/git_strategies/local_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/local_cache_strategy.rb
@@ -18,7 +18,9 @@ module GitStrategy
   class LocalCache
     class << self
       # TODO: make this conform to the same api as nfs strategy. don't need cache name, remote name, etc
-      def clone_and_checkout(tmp_dir, cached_repo_name, remote_name, repo_url, sha)
+      def clone_and_checkout(cached_repo_name, remote_name, repo_url, sha)
+        tmp_dir = Dir.mktmpdir(nil, Kochiku::Worker::GitRepo::WORKING_DIR)
+
         cached_repo_path = File.join(Kochiku::Worker::GitRepo::WORKING_DIR, cached_repo_name)
         synchronize_cache_repo(cached_repo_path, remote_name, repo_url, sha)
 
@@ -49,6 +51,8 @@ module GitStrategy
             run! "git submodule --quiet update"
           end
         end
+
+        tmp_dir
       end
 
       private

--- a/lib/kochiku/git_strategies/shared_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/shared_cache_strategy.rb
@@ -15,12 +15,11 @@ module GitStrategy
   #
   # Possible improvements:
   # 1. Add multiple shared roots and choose randomly between them. Poor man's client side load balancing.
-  # 2. For repos that are very large when checked out, a git clean -dfx and git checkout instead of a new
-  #    tmpdir would reduce disk i/o for a noticeable improvement.
   class SharedCache
     class << self
-      def clone_and_checkout(tmp_dir, repo_url, commit)
-        shared_repo_dir = File.join(Kochiku::Worker.settings.git_shared_root, repo_url.match(/.+?([^\/]+\/[^\/]+\.git)/)[1])
+      def clone_and_checkout(repo_url, commit)
+        repo_path = repo_url.match(/.+?([^\/]+\/[^\/]+\.git)\z/)[1]
+        shared_repo_dir = File.join(Kochiku::Worker.settings.git_shared_root, repo_path)
         raise 'cannot find repo in shared repos' unless Dir.exists?(shared_repo_dir)
 
         # check that commit exists
@@ -32,11 +31,19 @@ module GitStrategy
           end
         end
 
-        # clone
-        Cocaine::CommandLine.new('git', 'clone --quiet --shared --no-checkout :repo :dir').run(repo: shared_repo_dir, dir: tmp_dir)
+        repo_namespace_and_name = repo_path.chomp('.git')
+        repo_checkout_path = File.join(Kochiku::Worker::GitRepo::WORKING_DIR, repo_namespace_and_name)
 
-        Dir.chdir(tmp_dir) do
-          # checkout
+        # No `git fetch` is needed if the clone already exists because the NFS
+        # origin is continually up to date. However, a `git fetch` is needed if
+        # you are going to be referencing a branch name and not a commit
+        unless Dir.exist?(repo_checkout_path)
+          Cocaine::CommandLine.new('git', 'clone --quiet --shared --no-checkout :repo :dir').run(repo: shared_repo_dir, dir: repo_checkout_path)
+        end
+
+        Dir.chdir(repo_checkout_path) do
+          Cocaine::CommandLine.new('git', 'reset --hard').run
+          Cocaine::CommandLine.new('git', 'clean -dfx').run
           Cocaine::CommandLine.new('git', 'checkout --quiet :commit').run(commit: commit)
 
           # init submodules
@@ -54,6 +61,8 @@ module GitStrategy
             Cocaine::CommandLine.new('git', 'submodule update -- :path').run(path: path)
           end
         end
+
+        repo_checkout_path
       end
     end
   end

--- a/lib/kochiku/git_strategies/shared_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/shared_cache_strategy.rb
@@ -43,7 +43,7 @@ module GitStrategy
 
         Dir.chdir(repo_checkout_path) do
           Cocaine::CommandLine.new('git', 'reset --hard').run
-          Cocaine::CommandLine.new('git', 'clean -dfx').run
+          Cocaine::CommandLine.new('git', 'clean -dfx -f').run
           Cocaine::CommandLine.new('git', 'checkout --quiet :commit').run(commit: commit)
 
           # init submodules

--- a/lib/kochiku/jobs/build_attempt_job.rb
+++ b/lib/kochiku/jobs/build_attempt_job.rb
@@ -9,9 +9,7 @@ class BuildAttemptJob < JobBase
     @build_kind = build_options["build_kind"]
     @branch = build_options["branch"]
     @test_files = build_options["test_files"]
-    @repo_name = build_options["repo_name"]
     @test_command = build_options["test_command"]
-    @remote_name = build_options["remote_name"]
     @repo_url = build_options["repo_url"]
     @timeout = build_options["timeout"]
     @options = build_options["options"] || {}
@@ -38,7 +36,7 @@ class BuildAttemptJob < JobBase
     return if signal_build_is_starting(logstreamer_port) == :aborted
 
     Retryable.retryable(tries: 5, on: Kochiku::Worker::GitRepo::RefNotFoundError, sleep: 12) do   # wait for up to 60 seconds for the sha to be available
-      Kochiku::Worker::GitRepo.inside_copy(@repo_name, @remote_name, @repo_url, @build_ref) do
+      Kochiku::Worker::GitRepo.inside_copy(@repo_url, @build_ref) do
         begin
           options = @options.merge("git_commit" => @build_ref, "git_branch" => @branch, "kochiku_env" => @kochiku_env, "logstreamer_enabled" => !!logstreamer_port)
           result = run_tests(@build_kind, @test_files, @test_command, @timeout, options) ? :passed : :failed

--- a/spec/jobs/build_attempt_job_spec.rb
+++ b/spec/jobs/build_attempt_job_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe BuildAttemptJob do
       "build_ref" => build_ref,
       "build_kind" => build_part_kind,
       "test_files" => test_files,
-      "repo_name" => 'local-cache',
-      "remote_name" => "origin",
       "test_command" => "script/ci worker",
       "repo_url" => "git@github.com:square/kochiku-worker.git"
   } }
@@ -23,13 +21,9 @@ RSpec.describe BuildAttemptJob do
 
   subject { BuildAttemptJob.new(build_options) }
 
-  before do
-    FileUtils.mkdir_p(File.join(File.dirname(__FILE__), "..", "..", "tmp", "build-partition", "local-cache"))
-  end
-
   describe "#perform" do
     before do
-      allow(GitStrategy::LocalCache).to receive(:system).and_return(true)
+      allow(Kochiku::Worker::GitRepo).to receive(:inside_copy).and_yield
     end
 
     context "logstreamer port specified" do

--- a/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
+++ b/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 
 RSpec.describe GitStrategy::LocalCache do
   describe "#synchronize_with_remote" do
-    before { Retryable.enable }
+    before do
+      Retryable.configure do |config|
+        config.sleep_method = Proc.new { } # do nothing
+      end
+      Retryable.enable
+    end
     after { Retryable.disable }
 
     it "should throw an exception after the third fetch attempt" do
@@ -11,7 +16,7 @@ RSpec.describe GitStrategy::LocalCache do
       expect(fetch_double).to receive(:run).exactly(3).times.and_raise(Cocaine::ExitStatusError)
       expect(Cocaine::CommandLine).to receive(:new).with('git fetch', anything).and_return(fetch_double).exactly(3).times
 
-      expect { GitStrategy::LocalCache.send(:synchronize_with_remote, "master") }.to raise_error(Cocaine::ExitStatusError)
+      expect { GitStrategy::LocalCache.send(:synchronize_cache_repo) }.to raise_error(Cocaine::ExitStatusError)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,14 +37,5 @@ RSpec.configure do |config|
 
   config.before :each do
     WebMock.disable_net_connect!
-
-    # TODO: This is terrible. Need to either set up proper git fixtures, or
-    # figure out the right seams such that a fake object can be supplied.
-    allow(Cocaine::CommandLine).to receive(:new).
-      with("git config --get remote.origin.url").
-      and_return(double(:run => 'git@github.com:square/kochiku-worker.git'))
-    allow(Cocaine::CommandLine).to receive(:new).with('git fetch', anything) { double('git fetch', :run => nil, :exit_status => 0) }
-    allow(Cocaine::CommandLine).to receive(:new).with('git submodule update', anything) { double('git submodule update', :run => nil) }
-    allow(Cocaine::CommandLine).to receive(:new).with('git rev-list', anything) { double('git rev-list', :run => nil) }
   end
 end


### PR DESCRIPTION
Instead performing a git clone for each test job and tossing the repo away after the test completes, keep the clone of the repo and run git clean and git checkout in between jobs. The old approach had the benefit of being able to run more than 1 kochiku-worker side-by-side on the same machine however this setup is increasingly unlikely, especially as we move towards containers.

Also in this PR:
- LocalCache and SharedCache now have the same method signature
- LocalCache now stores cached repos inside their git namespace on the filesystem like SharedCache does
- Upgrade retryable to get sleep_method configuration setting