### PR TITLE
Rename one of the synchronize_cache_repo methods to run_git_fetch

### DIFF
--- a/lib/kochiku/git_strategies/local_cache_strategy.rb
+++ b/lib/kochiku/git_strategies/local_cache_strategy.rb
@@ -63,7 +63,7 @@ module GitStrategy
         end
         Dir.chdir(cached_repo_path) do
           harmonize_remote_url(repo_url)
-          synchronize_cache_repo
+          run_git_fetch
 
           if !commit.nil? && !system("git rev-list --quiet -n1 #{commit}")
             raise Kochiku::Worker::GitRepo::RefNotFoundError.new("Build Ref #{commit} not found in #{repo_url}")
@@ -83,8 +83,7 @@ module GitStrategy
         Cocaine::CommandLine.new("git clone", "--recursive #{repo_url} #{cached_repo_path}").run
       end
 
-      # fancy name for run 'git fetch' on the cache repo
-      def synchronize_cache_repo
+      def run_git_fetch
         exception_cb = Proc.new do |exception|
           Kochiku::Worker.logger.warn(exception)
         end

--- a/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
+++ b/spec/kochiku/git_strategies/local_cache_strategy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GitStrategy::LocalCache do
-  describe "#synchronize_with_remote" do
+  describe "#run_git_fetch" do
     before do
       Retryable.configure do |config|
         config.sleep_method = Proc.new { } # do nothing
@@ -16,7 +16,7 @@ RSpec.describe GitStrategy::LocalCache do
       expect(fetch_double).to receive(:run).exactly(3).times.and_raise(Cocaine::ExitStatusError)
       expect(Cocaine::CommandLine).to receive(:new).with('git fetch', anything).and_return(fetch_double).exactly(3).times
 
-      expect { GitStrategy::LocalCache.send(:synchronize_cache_repo) }.to raise_error(Cocaine::ExitStatusError)
+      expect { GitStrategy::LocalCache.send(:run_git_fetch) }.to raise_error(Cocaine::ExitStatusError)
     end
   end
 end


### PR DESCRIPTION
I accidentally created two methods with the same name in #55